### PR TITLE
Deleted about blurb on home page

### DIFF
--- a/app/presenters/home_presenter.rb
+++ b/app/presenters/home_presenter.rb
@@ -1,10 +1,9 @@
 class HomePresenter
-  attr_reader :about, :recent, :popular, :featured
+  attr_reader :recent, :popular, :featured
 
   def initialize
     # NOTE: This content needs to be created with this slug in order to
     #   populate the "about" blurb displayed on the home page.
-    @about = Misc.find_by(slug: 'about-short').try(:body).to_s
     @recent = Document.published.latest.limit(3).map do |d|
       DocumentPresenter.new d
     end


### PR DESCRIPTION
Deleted about blurb on home page and the code pulling from the source of the text for that page ("about blurb" under misc pages).